### PR TITLE
Automate tag and release of salt-ext-heist

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,54 @@
+name: Generate Tag and Github Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_version:
+        description: 'Release Version'
+        required: true
+      reTag:
+        description: 'Re Tag (Deletes tag and release)'
+        default: false
+
+jobs:
+  GenerateTagRelease:
+    name: Generate Tag and Github Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: dev-drprasad/delete-tag-and-release@v0.2.0
+      if: github.event.inputs.reTag == 'true'
+      with:
+        delete_release: true # default: false
+        tag_name: v${{ github.event.inputs.release_version }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - uses: actions/checkout@v2
+    - name: Bump version and push tag
+      id: tag_version
+      uses: mathieudutour/github-tag-action@v5.6
+      with:
+        create_annotated_tag: True
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        custom_tag: ${{ github.event.inputs.release_version }}
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v1
+      with:
+        python-version: 3.8
+
+    - uses: actions/checkout@v2
+      with:
+        ref: v${{ github.event.inputs.release_version }}
+    - name: Install pypa/build
+      run: |
+        python -m pip install build --user
+    - name: Build a binary wheel and a source tarball
+      run: |
+        python -m build --sdist --outdir dist/ .
+    - name: Create a GitHub release
+      uses: ncipollo/release-action@v1
+      with:
+        tag: ${{ steps.tag_version.outputs.new_tag }}
+        name: Release ${{ steps.tag_version.outputs.new_tag }}
+        artifacts: dist/saltext.salt-ext-heist*.tar.gz

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,17 +12,12 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: 3.7
-    - name: Set Cache Key
-      run: echo "PY=$(python --version --version | sha256sum | cut -d' ' -f1)" >> $GITHUB_ENV
-    - name: Install System Deps
+    - name: Run pre-commit
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libxml2 libxml2-dev libxslt-dev
-    - uses: actions/cache@v1
-      with:
-        path: ~/.cache/pre-commit
-        key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.0.1
+        pip3 install pre-commit
+        python3 -m pip install pre-commit
+        pre-commit clean
+        pre-commit run --color always --show-diff-on-failure -a -v
 
   Docs:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Create a Github Action that will automatically tag and generate a build. 

This is only missing one step -> To push the build to pypi. This will be done in a follow up PR once the repo is public.